### PR TITLE
Fix package.json: rename matter to matter-js, pin p5 version, set Nod…

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   "dependencies": {
     "bufferutil": "^4.0.3",
     "express": "^4.17.1",
-    "matter": "^0.14.2",
-    "p5": "",
+    "matter-js": "^0.14.2",
+    "p5": "^1.1.9",
     "socket.io": "^4.0.1"
   },
   "engines": {
-    "node": "12.x"
+    "node": "20.x"
   },
   "license": "",
   "keywords": []


### PR DESCRIPTION
…e 20.x

- matter-js is the correct npm package name (not "matter")
- Added explicit p5 version ^1.1.9 instead of empty string
- Node engine set to 20.x for Render compatibility

https://claude.ai/code/session_01Dz1TGhHAmd4dZKNzaSktih