### PR TITLE
Scale all elements 3x on mobile, add word tilt on spawn

### DIFF
--- a/public/sketch.js
+++ b/public/sketch.js
@@ -37,7 +37,8 @@ let circles = [];
 let grounds = [];
 let mConstraint;
 let canvas;
-let module = ((window.innerHeight / 100) * window.innerWidth) / 100 / 10;
+let isMobile = window.innerWidth < 768;
+let module = ((window.innerHeight / 100) * window.innerWidth) / 100 / 10 * (isMobile ? 3 : 1);
 let sizes = [
   module,
   module * 1.5,

--- a/public/word.js
+++ b/public/word.js
@@ -1,10 +1,11 @@
 class Word {
   constructor(x, y, txt, color) {
-    let fontSize = random(12, 20);
+    let isMobile = window.innerWidth < 768;
+    let fontSize = random(12, 20) * (isMobile ? 3 : 1);
     let w = txt.length * fontSize * 0.65;
     let h = fontSize * 1.2;
 
-    let options = { friction: 0.3, restitution: 0.5 };
+    let options = { friction: 0.3, restitution: 0.5, angle: random(-PI / 12, PI / 12) };
     this.body = Bodies.rectangle(x, y, w, h, options);
     this.txt = txt;
     this.color = color;


### PR DESCRIPTION
- Detect mobile (innerWidth < 768) and multiply `module` by 3, making Circle and Poke radii 3x larger on mobile screens
- Scale Word fontSize by 3x on mobile (was fixed 12-20px, unscaled)
- Add random ±15° initial tilt to Word via Bodies.rectangle angle option

https://claude.ai/code/session_01Dz1TGhHAmd4dZKNzaSktih