### PR TITLE
Make mobile elements substantially bigger (~3x from previously seen s…

### DIFF
--- a/public/sketch.js
+++ b/public/sketch.js
@@ -38,7 +38,9 @@ let grounds = [];
 let mConstraint;
 let canvas;
 let isMobile = window.innerWidth < 768;
-let module = ((window.innerHeight / 100) * window.innerWidth) / 100 / 10 * (isMobile ? 3 : 1);
+let module = isMobile
+  ? (window.innerWidth / 100) * 5
+  : ((window.innerHeight / 100) * window.innerWidth) / 100 / 10;
 let sizes = [
   module,
   module * 1.5,

--- a/public/word.js
+++ b/public/word.js
@@ -1,7 +1,10 @@
 class Word {
   constructor(x, y, txt, color) {
     let isMobile = window.innerWidth < 768;
-    let fontSize = random(12, 20) * (isMobile ? 3 : 1);
+    let fontSize = min(
+      random(12, 20) * (isMobile ? 9 : 1),
+      (window.innerWidth * 0.85) / (txt.length * 0.65)
+    );
     let w = txt.length * fontSize * 0.65;
     let h = fontSize * 1.2;
 


### PR DESCRIPTION
…izes)

- Replace area-based module formula on mobile with width-based: (innerWidth / 100) * 5, giving circles up to ~59px radius on 393px screen (vs ~30px before) — desktop formula is unchanged
- Word fontSize on mobile: 9x base (was 3x) capped by screen width / word length so long words always fit within 85% of screen width

https://claude.ai/code/session_01Dz1TGhHAmd4dZKNzaSktih