### PR TITLE
Set mobile word fontSize to 4x original (48-80px) with overflow cap

### DIFF
--- a/public/word.js
+++ b/public/word.js
@@ -1,10 +1,9 @@
 class Word {
   constructor(x, y, txt, color) {
     let isMobile = window.innerWidth < 768;
-    let fontSize = min(
-      random(12, 20) * (isMobile ? 9 : 1),
-      (window.innerWidth * 0.85) / (txt.length * 0.65)
-    );
+    let fontSize = isMobile
+      ? min(random(48, 80), (window.innerWidth * 0.85) / (txt.length * 0.65))
+      : random(12, 20);
     let w = txt.length * fontSize * 0.65;
     let h = fontSize * 1.2;
 


### PR DESCRIPTION
Previous multiplier approach was never reaching main (deployed branch). Now uses explicit 48-80px range on mobile (4x the 12-20px desktop range), capped by screen width / word length to prevent overflow.

https://claude.ai/code/session_01Dz1TGhHAmd4dZKNzaSktih