### PR TITLE
Add cache-busting version params to word.js and sketch.js script tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,8 +10,8 @@
     <script src="poke.js"></script>
     <script src="circle.js"></script>
     <script src="boundary.js"></script>
-    <script src="word.js"></script>
-    <script src="sketch.js"></script>
+    <script src="word.js?v=2"></script>
+    <script src="sketch.js?v=2"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Modak&display=swap" rel="stylesheet">


### PR DESCRIPTION
Forces browsers to fetch updated JS instead of serving cached old versions.

https://claude.ai/code/session_01Dz1TGhHAmd4dZKNzaSktih